### PR TITLE
Дебафф сватки, SCP-2908 и SCP-109

### DIFF
--- a/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp109.yml
+++ b/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp109.yml
@@ -19,9 +19,9 @@
     generated:
       reagents:
       - ReagentId: Water
-        Quantity: 2
+        Quantity: 2.5
       - ReagentId: Omnizine
-        Quantity: 1
+        Quantity: 0.5
   - type: GuideHelp
     guides:
     - ScpResearch

--- a/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp2908.yml
+++ b/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp2908.yml
@@ -25,6 +25,13 @@
   - type: Tag
     tags:
     - Scp2908
+  - type: RandomChanceTriggerCondition
+    successChance: 0.5
+  - type: TriggerOnEmptyGunshot
+  - type: ExplosionOnTrigger
+    intensitySlope: 6
+  - type: EmpOnTrigger
+    range: 5
 
 - type: entity
   id: MagazineScp2908
@@ -33,6 +40,7 @@
   parent: MagazinePistolSubMachineGunPPSH
   components:
   - type: BallisticAmmoProvider
+    capacity: 20
     whitelist:
       components:
       - CartridgeAmmo

--- a/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp2908.yml
+++ b/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp2908.yml
@@ -26,7 +26,7 @@
     tags:
     - Scp2908
   - type: RandomChanceTriggerCondition
-    successChance: 0.5
+    successChance: 0.25
   - type: TriggerOnEmptyGunshot
   - type: ExplosionOnTrigger
     intensitySlope: 6

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/armor.yml
@@ -53,9 +53,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.4 # Fire Edit
-        Slash: 0.4 # Fire Edit
-        Piercing: 0.3 # Fire edit
+        Blunt: 0.5 # Fire Edit
+        Slash: 0.5 # Fire Edit
+        Piercing: 0.5 # Fire edit
         Heat: 0.6
         Radiation: 0.6
         Caustic: 0.6


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
куеукекеке4ууенерег6егег

## Ссылка на багрепорт/Предложение
<!--
Ссылки на Дискуссии и Баг-репорты указывать здесь.
-->

## Медиа (Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения, вы обязаны предоставить скриншоты/видео изменений.
-->

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR'а.

- [ ] Task 1
- [ ] Task 2
-->

<!--
## Требования к картам

Если ваше изменение требует изменение на картах - опишите требования тут.
Так мапперы серверов смогут понять, как адаптировать карты под ваши изменения.


-->

**Changelog**

<!--
=== КАК ПИСАТЬ ЧЕЙНЖЛОГ ===

[Подробная инструкция и полный пример](https://github.com/makura-games/sunrise-station/blob/master/Tools/_sunrise/changelog/README.md)

1) Не считайте тип чейнжлога частью вашего предложения.
add: Новая фича = ПЛОХО | add: Добавлена новая фича = ХОРОШО
2) Подробно описывайте, что вы добавили и как это использовать. Все должно быть в меру.
fix: Исправлены мелочи = УЖАСНО | fix: Исправлена невозможность игроков двигаться = ХОРОШО
3) Не добавляйте технические детали. Чейнжлог пишется для игроков.
add: Добавлен новый хелпер-метод = ПЛОХО | НИЧЕГО НЕ ПИСАТЬ = ХОРОШО
* Иногда чейнжлог не нужен. Просто удалите это поле.

Добавляйте `media:` сразу после той записи, к которой относится изображение или видео:
`add: Добавлена новая рыба`
`media: ![Рыба в игре](https://example.org/fish.png)`
`media: [Демонстрация механики](https://example.org/demo.webm)`

Продолжайте текст записи на следующих строках; переносы сохранятся в Discord:
`fix: Первая строка исправления`
`Вторая строка той же записи`

-->

:cl: timur
- tweak: Характеристики SWAT изменены с 60 ударных до 50, 60 режущих до 50, 70 колотых до 50
- tweak: Теперь SCP-2908 с небольшим шансом может взорваться при стрельбе
- tweak: Вместимость патронов в магазине SCP-2908 изменена с 35 до 20 единиц
- tweak: Генерация жидкости в SCP-109 изменена с 2 воды и 1 омнизина до 2.5 воды и 0.5 омнизина


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Изменения игрового баланса**
  * У SCP-109 увеличено количество генерируемой воды с 2 до 2,5 единиц, а количество Omnizine снижено с 1 до 0,5.
  * Для SCP-2908 добавлено 25%-ное срабатывание при выстреле из пустого оружия со взрывом и EMP-эффектом.
  * Вместимость магазина SCP-2908 установлена на уровне 20 патронов.
  * Усилена защита бронекостюма SWAT от дробящего, рубящего и пробивающего урона до 50%.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->