### PR TITLE
Замена способности всасывания горящих сущностей на автоматическую механику у SCP-457

### DIFF
--- a/Content.Server/_Scp/Scp457/Scp457Component.cs
+++ b/Content.Server/_Scp/Scp457/Scp457Component.cs
@@ -38,7 +38,7 @@ public sealed partial class Scp457Component : Component
     [DataField]
     public float DamageModifierFlammableAdd = 0.1f;
 
-	[DataField]
+    [DataField]
     public float ObjectWaterSizeDecrease = 0.01f;
 
     [DataField]
@@ -59,6 +59,9 @@ public sealed partial class Scp457Component : Component
     [DataField]
     public HashSet<string> FlammableMaterialsWhitelist = ["Wood", "Paper", "Cardboard", "Cloth", "Carpet"];
 
+    [DataField]
+    public TimeSpan AutoAbsorbInterval = TimeSpan.FromSeconds(5);
+
     [ViewVariables]
     public float AppliedObjectSize = 1f;
 
@@ -67,4 +70,7 @@ public sealed partial class Scp457Component : Component
 
     [ViewVariables]
     public TimeSpan? NextChangeObjectSize;
+
+    [ViewVariables]
+    public TimeSpan? NextAutoAbsorb;
 }

--- a/Content.Server/_Scp/Scp457/Scp457System.cs
+++ b/Content.Server/_Scp/Scp457/Scp457System.cs
@@ -6,7 +6,6 @@ using Content.Shared._Scp.Helpers;
 using Content.Shared._Scp.Mobs.Components;
 using Content.Shared._Scp.Other.Events;
 using Content.Shared._Scp.SafeTime;
-using Content.Shared._Scp.Scp457;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
@@ -59,7 +58,6 @@ public sealed class Scp457System : EntitySystem
         _scpQuery = GetEntityQuery<ScpComponent>();
 
         SubscribeLocalEvent<Scp457Component, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<Scp457Component, Scp457AbsorbActionEvent>(OnAbsorbAction);
         SubscribeLocalEvent<Scp457Component, ScpIngestionConsumedEvent>(OnConsumed);
         SubscribeLocalEvent<Scp457Component, HitByWaterEvent>(OnHitByWater);
         SubscribeLocalEvent<Scp457Component, VentCrawlAttemptEvent>(OnVentCrawlAttempt);
@@ -73,6 +71,12 @@ public sealed class Scp457System : EntitySystem
         var query = EntityQueryEnumerator<Scp457Component>();
         while (query.MoveNext(out var uid, out var scp457))
         {
+            if (scp457.NextAutoAbsorb < _timing.CurTime)
+            {
+                TryAbsorbNearby((uid, scp457));
+                scp457.NextAutoAbsorb = _timing.CurTime + scp457.AutoAbsorbInterval;
+            }
+
             if (scp457.NextChangeObjectSize > _timing.CurTime)
                 continue;
 
@@ -86,6 +90,7 @@ public sealed class Scp457System : EntitySystem
     {
         ent.Comp.AppliedObjectSize = ent.Comp.ObjectSize;
         ent.Comp.NextChangeObjectSize = _timing.CurTime + DecayInterval;
+        ent.Comp.NextAutoAbsorb = _timing.CurTime + ent.Comp.AutoAbsorbInterval;
 
         if (TryComp<PassiveDamageComponent>(ent, out var passiveDamage))
             ent.Comp.BasePassiveDamage = new DamageSpecifier(passiveDamage.Damage);
@@ -100,14 +105,6 @@ public sealed class Scp457System : EntitySystem
             return;
 
         TryChangeSize(ent, ent.Comp.ObjectSizeFlammableAdd);
-    }
-
-    private void OnAbsorbAction(Entity<Scp457Component> ent, ref Scp457AbsorbActionEvent args)
-    {
-        if (args.Handled)
-            return;
-
-        args.Handled = TryAbsorbNearby(ent);
     }
 
     public bool TryAbsorbNearby(Entity<Scp457Component> ent)

--- a/Content.Shared/_Scp/Scp457/Scp457Events.cs
+++ b/Content.Shared/_Scp/Scp457/Scp457Events.cs
@@ -1,5 +1,0 @@
-using Content.Shared.Actions;
-
-namespace Content.Shared._Scp.Scp457;
-
-public sealed partial class Scp457AbsorbActionEvent : InstantActionEvent;

--- a/Resources/Prototypes/_Scp/Actions/scp457.yml
+++ b/Resources/Prototypes/_Scp/Actions/scp457.yml
@@ -1,21 +1,4 @@
 - type: entity
-  id: Scp457Absorb
-  name: Absorb fuel
-  description: Absorb all the fuel around you.
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: Action
-    useDelay: 30
-    icon:
-      sprite: _Scp/Mobs/Scp/scp-457.rsi
-      state: fireguy
-    itemIconStyle: BigAction
-    raiseOnUser: true
-  - type: InstantAction
-    event: !type:Scp457AbsorbActionEvent
-  - type: SafeTimeRestricted
-
-- type: entity
   parent: BaseAction
   id: Scp457Fire
   name: Ignite tile

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp457.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp457.yml
@@ -29,7 +29,6 @@
   - type: VentCrawler
   - type: ActionGrant
     actions:
-    - Scp457Absorb
     - Scp457Fire
   - type: FearSource
     uponSeenState: None


### PR DESCRIPTION
## Краткое описание
Замена способности всасывания горящих элементов на автоматическую механику у SCP-457

:cl: Wardex
- tweak: SCP-457 теперь каждые 5 секунд всасывает ближайшие сущности поблизости, которые могут гореть
:end-cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения игрового процесса**
  * Поглощение ближайших объектов SCP-457 теперь происходит автоматически с интервалом в 5 секунд.
  * Убрано ручное действие «Поглотить топливо».
  * SCP-457 теперь получает только действие, связанное с использованием огня.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->